### PR TITLE
Fix error logging function + additional command flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const { argv } = require('yargs');
 var commandExists = require('command-exists');
 
 const timestamp = Date.now();
-const command = argv._[0] || argv.command;
+const command = argv._[0] || argv.command || argv.c;
 const directory = argv._[1] || argv.directory || argv.dir || argv.d || 'packages';
 const cliTool = commandExists.sync('yarn') ? 'yarn' : 'npm run';
 
 if (!command) {
-  log.error('No command to run passed');
+  console.error('No command to run passed');
   shell.exit(1);
 }
 


### PR DESCRIPTION
Fixes:
- use `console.error` instead of non-existent `log.error` for error logging

Adds:
- `-c` flag for `command` to be passed