### PR TITLE
Adds installation instructions and few missing links in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,11 @@
 ## ⚠️ MVP - Solution. API might change.
 
-Optional scripts are not yet supported by `yarn workspaces`.
-This solution fills the gap as yarn will crash if at least one workspace doesn't have called script.
+Optional scripts are not yet supported by [`yarn workspaces`](https://yarnpkg.com/lang/en/docs/workspaces/).
+This solution fills the gap as [`yarn`](https://yarnpkg.com/) will crash if at least one workspace doesn't have called script.
+
+#### Instal:
+
+`yarn add -D -W optional-workspace-command`
 
 #### Usage:
 
@@ -13,6 +17,9 @@ In your `package.json` scripts add:
 
 This will run command in all packages under `package/{package_dir}` optionally.
 In other words, if no `build` script found in `package.json` - dir is skipped.
+
+**Note:** You can also use script without installing via [`npx`](https://www.npmjs.com/package/npx):  
+`npx optional-workspace-command build`
 
 #### Options:
 


### PR DESCRIPTION
Adds:
- installation instructions via `yarn`
- a basic example of usage via `npx`
- few missing links on `yarn`, `yarn workspaces`,  and `npx` keywords