### PR TITLE
Sets npm registry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "clean-git": "git branch --merged master --no-color | grep -v master | grep -v stable | xargs git branch -d",
     "clean-yarn": "rm -rf node_modules && yarn cache clean && yarn"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
   "keywords": [
     "yarn",
     "script",


### PR DESCRIPTION
Adds:
- set npm registry in `package.json`

Motivation: I'm working with packages from multiple registries on one laptop, this way it is easier to publish.